### PR TITLE
Added SASL support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+factoids.txt
+std

--- a/config.lamb
+++ b/config.lamb
@@ -1,13 +1,14 @@
 -- config constants
 
-HOST = "127.0.0.1".
+HOST = "irc.freenode.net".
 PORT = 6667.
 NICK = "lambot".
+PASS = "".
 
 LASTFM_API_KEY = "YOUR_LASTFM_API_KEY_HERE".
 
 -- nicks of administrators
-ADMINS = ["darkf"].
+ADMINS = ["darkf", "nchambers"].
 
 -- channels to join
-CHANS = ["#lobby"].
+CHANS = ["##eggnog"].

--- a/config.lamb
+++ b/config.lamb
@@ -1,14 +1,14 @@
 -- config constants
 
-HOST = "irc.freenode.net".
+HOST = "127.0.0.1".
 PORT = 6667.
 NICK = "lambot".
-PASS = "".
+PASS = "YOUR_PASS_HERE".
 
 LASTFM_API_KEY = "YOUR_LASTFM_API_KEY_HERE".
 
 -- nicks of administrators
-ADMINS = ["darkf", "nchambers"].
+ADMINS = ["darkf"].
 
 -- channels to join
-CHANS = ["##eggnog"].
+CHANS = ["#lounge"].

--- a/irc.lamb
+++ b/irc.lamb
@@ -1,3 +1,4 @@
+import("std/base64").
 import("std/list").
 import("std/str").
 import("std/http").
@@ -262,9 +263,27 @@ handleCommand(s, _, "251", _) -> s. -- There are X users and Y services on Z ser
 handleCommand(s, _, "331", _) -> s. -- No topic is set
 handleCommand(s, _, "366", _) -> s. -- End of NAMES list
 
+handleCommand(s, _, "CAP", ["*", "ACK", "sasl "]) -> do
+    putstrln("Starting SASL handshake.");
+    fputstr(sock, "AUTHENTICATE PLAIN\r\n")
+end.
+
+handleCommand(s, _, "AUTHENTICATE", ["+"]) -> do
+    auth = base64\base64_encode(config\NICK + "\0" + config\NICK + "\0" + config\PASS);
+    fputstr(sock, "AUTHENTICATE " + auth + "\r\n")
+end.
+
+handleCommand(s, _, "903", _) -> do
+    putstrln("SASL authentication successful.");
+    fputstr(sock, "CAP END\r\n");
+    fputstr(sock, "NICK " + config\NICK + "\r\n");
+    fputstr(sock, "USER " + config\NICK + " 0 * :Lamb Da. Bot\r\n");
+    joinChans() -> list\map(\chan -> fputstr(sock, "JOIN " + chan + "\r\n"), config\CHANS);
+    joinChans()
+end.
+
 handleCommand(s, src, cmd, args) -> do
-	putstrln("Unhandled command: " + cmd + ", with args: " + repr(args) + " from " + src);
-	s
+	putstrln("Unhandled command: " + cmd + ", with args: " + repr(args) + " from " + src)
 end.
 
 handleLine(s, ":" :: line) -> do
@@ -286,13 +305,15 @@ end.
 sock = sockopen(config\HOST, config\PORT).
 
 -- send introduction
-fputstr(sock, "PASS " + config\NICK + "\r\n").
-fputstr(sock, "NICK " + config\NICK + "\r\n").
-fputstr(sock, "USER " + config\NICK + " 0 * :Lamb Da. Bot\r\n").
-
--- note: workaround for issue #19 (passing lambdas to modules in the global scope is incorrect)
-joinChans() -> list\map(\chan -> fputstr(sock, "JOIN " + chan + "\r\n"), config\CHANS).
-joinChans().
+if config\PASS == "" then do
+    fputstr(sock, "NICK " + config\NICK + "\r\n");
+    fputstr(sock, "USER " + config\NICK + " 0 * :Lamb Da. Bot\r\n");
+    joinChans() -> list\map(\chan -> fputstr(sock, "JOIN " + chan + "\r\n"), config\CHANS);
+    joinChans()
+end
+else do
+    fputstr(sock, "CAP REQ :sasl\r\n")
+end.
 
 -- loop receiving lines
 mainloop(state) ->


### PR DESCRIPTION
Adds basic SASL support for lambot. Only tested on the freenode network, and at this time has no error handling if the incorrect credentials are used.